### PR TITLE
Fix build on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ system_shutdown = "4.0"
 qrcode-generator = "4.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["winuser", "wincrypt", "shellscalingapi", "pdh", "synchapi", "memoryapi"] }
+winapi = { version = "0.3", features = ["winuser", "wincrypt", "shellscalingapi", "pdh", "synchapi", "memoryapi", "shellapi"] }
 winreg = "0.11"
 windows-service = "0.6"
 virtual_display = { path = "libs/virtual_display", optional = true }


### PR DESCRIPTION
`winapi::um::shellapi` is used in https://github.com/rustdesk/rustdesk/blob/master/src/platform/windows.rs but not declared in `Cargo.toml` resulting in a compilation error, when I tried building on Windows, this change adds shellapi as a dependency.